### PR TITLE
Add FR News Only filter on news page

### DIFF
--- a/src/app/pages/news/news.page.ts
+++ b/src/app/pages/news/news.page.ts
@@ -106,6 +106,10 @@ import { BasePage } from '../base.page';
                 <p-checkbox [(ngModel)]="onlyEnglish" [binary]="true" size="small" class="flex"/>
                 <label class="ml-1">EN News Only</label>
             </div>
+            <div class="flex items-center mr-2">
+                <p-checkbox [(ngModel)]="onlyFrench" [binary]="true" size="small" class="flex"/>
+                <label class="ml-1">FR News Only</label>
+            </div>
 
             @if (topicOptions().length) {
                 <app-menu class="z-20" queryParam="topic" label="Topic" [options]="topicOptions()" showClear/>
@@ -157,6 +161,7 @@ export default class NewsPage extends BasePage implements OnInit {
     public loadedDate$ = new BehaviorSubject(new Date());
     public isLoading$ = new BehaviorSubject(false);
     public onlyEnglish = signal(false);
+    public onlyFrench = signal(false);
     public news$: Observable<ElasticNewsItem[]> = EMPTY;
     public cloudData$: Observable<CloudData[]> = EMPTY;
     public sentimentAverage$: Observable<number> = EMPTY;
@@ -178,6 +183,7 @@ export default class NewsPage extends BasePage implements OnInit {
     private setupNews() {
         const topic$ = toObservable(this.topic, { injector: this.injector });
         const onlyEnglish$ = toObservable(this.onlyEnglish, { injector: this.injector });
+        const onlyFrench$ = toObservable(this.onlyFrench, { injector: this.injector });
 
         return this.shownDate$.pipe(
             filter(() => !this.isLoading$.value),
@@ -187,13 +193,13 @@ export default class NewsPage extends BasePage implements OnInit {
                 this.isLoading$.next(false);
                 this.loadedDate$.next(this.shownDate$.value);
             }),
-            combineLatestWith(topic$, onlyEnglish$),
-            map(([ news, topic, onlyEnglish ]) => this.filterNews(news, topic, onlyEnglish)),
+            combineLatestWith(topic$, onlyEnglish$, onlyFrench$),
+            map(([ news, topic, onlyEnglish, onlyFrench ]) => this.filterNews(news, topic, onlyEnglish, onlyFrench)),
             shareReplay(1),
         );
     }
 
-    private filterNews(news: ElasticNewsItem[], topic: string | undefined, onlyEnglish: boolean) {
+    private filterNews(news: ElasticNewsItem[], topic: string | undefined, onlyEnglish: boolean, onlyFrench: boolean) {
         return news
             .filter(newsItem => {
                 if (topic) {
@@ -206,6 +212,13 @@ export default class NewsPage extends BasePage implements OnInit {
             .filter(newsItem => {
                 if (onlyEnglish) {
                     return newsItem.lang === 'eng';
+                }
+
+                return true;
+            })
+            .filter(newsItem => {
+                if (onlyFrench) {
+                    return newsItem.lang === 'fra';
                 }
 
                 return true;


### PR DESCRIPTION
Mirrors the existing EN News Only checkbox so users can narrow articles to French-language sources (lang === 'fra') alongside the English filter.