### PR TITLE
fix(build): pin @types/google.maps to 3.58.1 (fix Cloudflare prod build)

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,5 +45,10 @@
     "postcss": "^8.4.32",
     "tailwindcss": "^3.4.0",
     "typescript": "~5.5.4"
+  },
+  "pnpm": {
+    "overrides": {
+      "@types/google.maps": "3.58.1"
+    }
   }
 }


### PR DESCRIPTION
## Problem

The Cloudflare Pages **production** build fails:

```
✘ TS2694: Namespace 'google.maps.visualization' has no exported member 'WeightedLocation'.
✘ TS2694: Namespace 'google.maps.visualization' has no exported member 'HeatmapLayerOptions'.
    node_modules/@angular/google-maps/index.d.ts
```

## Root cause

- `@angular/google-maps` depends on `@types/google.maps@^3.54.10`.
- CI runs **pnpm 8.7.1**, but the committed `pnpm-lock.yaml` is `lockfileVersion 9.0`, so pnpm logs `Ignoring not compatible lockfile` and resolves the **latest** types — `@types/google.maps@3.65.1`.
- Newer `@types/google.maps` **removed** the deprecated Heatmap visualization members (`WeightedLocation`, `HeatmapLayerOptions`) that `@angular/google-maps` still references → type error.

Verified: `3.65.1` exports **0** of those members; `3.58.1` exports **9**. Local dev builds passed only because `node_modules` already had the older `3.58.1`.

## Fix

Pin via a pnpm override to the last good version:

```json
"pnpm": { "overrides": { "@types/google.maps": "3.58.1" } }
```

pnpm applies `pnpm.overrides` from `package.json` even when it ignores the lockfile, so the pin holds on CI's fresh install. Verified `ng build --configuration production` passes locally.

## Follow-up (not in this PR)

The deeper issue is that CI ignores the lockfile (pnpm 8.7.1 vs lockfile v9), making every install non-reproducible. Worth adding a `"packageManager": "pnpm@9.x"` field (so Cloudflare's corepack uses a pnpm that honors the v9 lockfile) and/or regenerating a compatible lockfile.

🤖 Generated with [Claude Code](https://claude.com/claude-code)