### PR TITLE
fix(news): skip empty days so OER pilots show news immediately

### DIFF
--- a/src/app/pages/news/news.page.ts
+++ b/src/app/pages/news/news.page.ts
@@ -4,7 +4,7 @@ import { toObservable, toSignal } from '@angular/core/rxjs-interop';
 import { FormsModule } from '@angular/forms';
 import { CloudData, TagCloudComponent } from 'angular-tag-cloud-module';
 import { Checkbox } from 'primeng/checkbox';
-import { BehaviorSubject, combineLatestWith, delay, distinctUntilChanged, EMPTY, filter, fromEvent, map, Observable, pairwise, shareReplay, skip, startWith, switchMap, tap } from 'rxjs';
+import { BehaviorSubject, combineLatestWith, distinctUntilChanged, EMPTY, filter, fromEvent, map, Observable, shareReplay, switchMap, tap, timer } from 'rxjs';
 import { UNESCO_REGIONS } from '../../../../configuration/regions/unesco-regions';
 import { ElasticNewsItem } from '../../../../functions/api/news/articles/interface/elastic-news-item';
 import { NewsService } from '../../domain/news/service/news.service';
@@ -218,7 +218,7 @@ export default class NewsPage extends BasePage implements OnInit {
             })
             .filter(newsItem => {
                 if (region) {
-                    return newsItem.UNESCO_region === region;
+                    return (newsItem.UNESCO_region ?? '').trim() === region;
                 }
 
                 return true;
@@ -271,12 +271,13 @@ export default class NewsPage extends BasePage implements OnInit {
     }
 
     private startCounter() {
-        return this.isLoading$.pipe(
-            skip(1),
-            startWith(true),
-            pairwise(),
-            filter(([ prev, next ]) => prev && !next),
-            delay(5000),
+        // Drive the date walk off the rendered news: dwell on days that have
+        // news, but skip empty days near-instantly so pilots whose latest news
+        // is weeks old don't sit on a blank "No news today" screen. The dwell
+        // applies to the filtered result, so an active region/topic filter also
+        // skips straight to days that have matching news.
+        return this.news$.pipe(
+            switchMap(news => timer(news.length ? this.dwellMs : this.skipMs)),
             tap(() => {
                 const currentDate = new Date(this.shownDate$.value);
 
@@ -288,6 +289,9 @@ export default class NewsPage extends BasePage implements OnInit {
             }),
         ).subscribe();
     }
+
+    private readonly dwellMs = 5000;
+    private readonly skipMs = 100;
 
     private get minDate() {
         const maxDaysBack = 31;


### PR DESCRIPTION
## Problem

\"Region filter ne dela pri vseh OER1–OER5.\" Investigating the live API showed the **filter actually works** for all five pilots — every UNESCO region returns matching articles. The real cause is the date-walk:

`startCounter()` starts at **today** and steps back one day every **5s**. OER pilots have no recent news — the latest populated day is days-to-weeks old:

| pilot | latest day with news | blank wait before |
|-------|----------------------|-------------------|
| OER3/OER4 | −1 day | ~5s |
| OER5 | −4 days | ~20s |
| OER2 | −7 days | ~35s |
| OER1 | −10 days | ~50s |

So OER3/4/5 showed news quickly while OER1/OER2 sat on a blank \"No news today\" for ~35–50s — looking broken.

## Fix

- **Skip empty days fast.** `startCounter()` now drives off the rendered `news$`: it dwells **5s** on days that have news but advances after **100ms** on empty days, walking to the latest populated day almost immediately. The HTTP round-trip naturally throttles the scan. Because the dwell keys off the *filtered* result, an active region/topic filter also skips straight to days that have matching news.
- **Trim `UNESCO_region`.** The index has a stray `' Africa'` (leading space) value; comparing `(UNESCO_region ?? '').trim() === region` lets it match the `Africa` option.

## Notes

- This changes the date-walk for **all** news pages (not just OER), which is an improvement everywhere — empty days are no longer dwelt on. Confirmed with the SDG pages in mind; behaviour on populated days (5s dwell) is unchanged.
- Not fixed here (data-side): ~12–43% of OER articles have `UNESCO_region = null` (no detected location); those are excluded whenever a region is selected. That's a tagging gap in the index, not the widget.
- Verified `ng build --configuration production` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)