### PR TITLE
feat(news): jump straight to the latest day with news

### DIFF
--- a/src/app/domain/news/service/news.service.ts
+++ b/src/app/domain/news/service/news.service.ts
@@ -1,6 +1,6 @@
 import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { inject, Injectable } from '@angular/core';
-import { catchError, map, Observable, of, shareReplay } from 'rxjs';
+import { catchError, concatMap, first, forkJoin, from, map, Observable, of, shareReplay } from 'rxjs';
 import { environment } from '../../../../../environment/environment';
 import { ElasticNewsItem } from '../../../../../functions/api/news/articles/interface/elastic-news-item';
 import { CloudTagResponse } from '../../../../../functions/api/news/tags/interface/cloud-tag-response.interface';
@@ -27,6 +27,44 @@ export class NewsService {
             }),
             shareReplay(1)
         )
+    }
+
+    /**
+     * Finds the most recent day (<= today, within `maxDaysBack`) that actually has news for
+     * the given sdg/pilot. Probes days newest-first in parallel batches and returns the newest
+     * day with a hit — so the widget can land straight on data instead of walking day-by-day
+     * through empty dates. Returns null if no day in the window has news.
+     */
+    public getLatestNewsDate(
+        sdg: number,
+        pilot: string,
+        maxDaysBack = 31,
+        batchSize = 10,
+        today = new Date()
+    ): Observable<Date | null> {
+        const days = Array.from({ length: maxDaysBack + 1 }, (_, i) => {
+            const date = new Date(today);
+            date.setDate(date.getDate() - i);
+            return date;
+        });
+
+        const batches: Date[][] = [];
+        for (let i = 0; i < days.length; i += batchSize) {
+            batches.push(days.slice(i, i + batchSize));
+        }
+
+        return from(batches).pipe(
+            // Probe each batch (newest-first) in parallel; only continue to the next batch
+            // if the current one had no news at all.
+            concatMap(batch => forkJoin(
+                batch.map(date => this.getNews(sdg, pilot, date).pipe(
+                    map(news => ({ date, hasNews: news.length > 0 }))
+                ))
+            ).pipe(
+                map(results => results.find(result => result.hasNews)?.date ?? null)
+            )),
+            first(date => date !== null, null),
+        );
     }
 
     public getCloudTags(sdg: string, pilot: string, startDate: Date, endDate: Date, limit: number): Observable<Tag[]> {

--- a/src/app/pages/news/news.page.ts
+++ b/src/app/pages/news/news.page.ts
@@ -184,6 +184,17 @@ export default class NewsPage extends BasePage implements OnInit {
         this.cloudData$ = this.setupTags();
         this.sentimentAverage$ = this.setupSentimentAverage();
         this.startCounter();
+        this.jumpToLatestNewsDate();
+    }
+
+    // Pilots can have no news for many recent days. Probe for the most recent day that
+    // actually has news and jump straight to it, so the widget lands on data instead of
+    // walking day-by-day through empty dates.
+    private jumpToLatestNewsDate() {
+        this.newsService.getLatestNewsDate(+this.sdg()!, this.pilot()!).subscribe(latestDate => {
+            this.latestDate = latestDate ?? new Date();
+            this.shownDate$.next(this.latestDate);
+        });
     }
 
     private setupNews() {
@@ -284,7 +295,9 @@ export default class NewsPage extends BasePage implements OnInit {
                 if (currentDate >= this.minDate) {
                     this.shownDate$.next(new Date(currentDate.setDate(currentDate.getDate() - 1)));
                 } else {
-                    this.shownDate$.next(new Date());
+                    // Restart the rotation at the latest day with news (not today), so we
+                    // don't re-walk the empty recent days every cycle.
+                    this.shownDate$.next(this.latestDate ?? new Date());
                 }
             }),
         ).subscribe();
@@ -292,6 +305,7 @@ export default class NewsPage extends BasePage implements OnInit {
 
     private readonly dwellMs = 5000;
     private readonly skipMs = 100;
+    private latestDate?: Date;
 
     private get minDate() {
         const maxDaysBack = 31;


### PR DESCRIPTION
## Problem

Even after the 100ms empty-day skip (#30), the news widget still felt broken for OER pilots: it starts at **today** and steps back **one day per network request**. OER pilots have no news for many recent days (OER1's latest is ~10 days back, OER2 ~7), so it visibly walked through blank "No news today" screens — one request per empty day, latency-bound — before landing on data.

## Fix (client-side parallel probe)

- **`NewsService.getLatestNewsDate(sdg, pilot, maxDaysBack=31, batchSize=10)`** — probes recent days **newest-first in parallel batches** (`forkJoin` per batch, `concatMap` + `first` to early-exit on the first batch with a hit) and returns the most recent day that has news, or `null` if the window is empty. Reuses the existing `getNews()` (already returns `[]` on empty/error).
- **`news.page.ts`** — on init, jump `shownDate$` straight to that day (`jumpToLatestNewsDate()`); fall back to today if none. The rotation's reset branch now restarts at `latestDate` instead of `new Date()`, so it doesn't re-walk the empty recent days every cycle. The existing dwell/skip rotation is unchanged for in-window days.

## Verified

- `ng build --configuration production` passes.
- Simulated the probe against the live API — it lands exactly where expected:
  - `?pilot=OER1` → **2026-05-27** (10 days back)
  - `?pilot=OER5` → **2026-06-02** (4 days back)
  
  So instead of ~50s of walking, OER1 lands on data after ~2 batch round-trips.

## Notes

- The probe keys off raw pilot/sdg news (ignores the selected region/topic/EN-FR filter). It lands on the latest day with *any* news; if a region filter is active and that day has none matching, the existing skip rotation handles it. A filter-aware probe can come later.
- **Caching (separate, not in this PR):** `index.html` is served `max-age=86400` (set in the Cloudflare dashboard, not the repo `_headers`), so other users keep loading the old shell until cache expires. Recommend purging the Cloudflare Pages cache after deploy and serving HTML as `no-cache`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)