### PR TITLE
fix(cache): stop long-caching the SPA shell (fixes stale widget after deploy)

### DIFF
--- a/functions/middleware/cache-control.middleware.ts
+++ b/functions/middleware/cache-control.middleware.ts
@@ -2,7 +2,17 @@ export const cacheControlMiddleware: PagesFunction = async ({ next }) => {
     const response = await next();
 
     if (response.status === 200) {
-        response.headers.set('Cache-Control', 'public, max-age=86400');
+        const contentType = response.headers.get('Content-Type') ?? '';
+
+        if (contentType.includes('text/html')) {
+            // The SPA shell (index.html / navigations) must always revalidate, otherwise a
+            // deploy stays invisible for up to a day because the old shell keeps pointing at
+            // the old hashed JS bundles. The bundles themselves are content-hashed, so the
+            // long cache below is safe for them.
+            response.headers.set('Cache-Control', 'no-cache');
+        } else {
+            response.headers.set('Cache-Control', 'public, max-age=86400');
+        }
     }
 
     return response;

--- a/functions/middleware/cache.middleware.ts
+++ b/functions/middleware/cache.middleware.ts
@@ -12,7 +12,11 @@ export const cacheMiddleware: PagesFunction = async ({ request, next }) => {
     }
     const response = await next();
 
-    if (response.status === 200) {
+    // Never cache the SPA shell (index.html / navigations) — it must always be re-fetched so
+    // a new deploy is picked up immediately. Hashed assets and API responses still get cached.
+    const isHtml = (response.headers.get('Content-Type') ?? '').includes('text/html');
+
+    if (response.status === 200 && !isHtml) {
         console.log('Caching response', cacheKey);
         await cache.put(cacheKey, response.clone());
     }

--- a/functions/middleware/cache.middleware.ts
+++ b/functions/middleware/cache.middleware.ts
@@ -2,7 +2,11 @@ export const cacheMiddleware: PagesFunction = async ({ request, next }) => {
     const cache = caches.default;
     const cacheKey = request.url;
 
-    if (request.headers.get('Cache-Control') !== 'no-cache') {
+    // Navigation requests (the SPA shell) must never be served from cache — neither read nor
+    // written — so a new deploy is picked up immediately instead of staying stale for ~24h.
+    const wantsHtml = (request.headers.get('Accept') ?? '').includes('text/html');
+
+    if (!wantsHtml && request.headers.get('Cache-Control') !== 'no-cache') {
         const cachedResponse = await cache.match(cacheKey);
 
         if (cachedResponse) {


### PR DESCRIPTION
## Problem

After a deploy, users keep seeing the **old** widget (e.g. OER still shows "Topic" instead of the new "Region" dropdown), and a browser **hard refresh does not help**.

Root cause is in the repo's Pages middleware (`functions/_middleware.ts`):
- `cache-control.middleware.ts` set `Cache-Control: public, max-age=86400` on **every** 200 response — **including `index.html`**.
- `cache.middleware.ts` also stored every 200 in Cloudflare's Worker cache (`caches.default`) by URL.

So the SPA shell was cached for 24h at the edge. The shell points at content-hashed JS bundles; when a new deploy produces new bundles, the cached shell still references the **old** ones → the new feature stays invisible until the TTL expires. Hard refresh can't fix it because the edge cache ignores the browser's `no-cache`.

Verified live: `/news?pilot=OER1` returns `cf-cache-status: HIT, age: 10151`, `cache-control: public, max-age=86400`, serving the **old** bundle `main-JL52EWD3.js`; the same URL with a unique `?v=` param serves the new `main-AWXDQYFJ.js` (with the Region dropdown).

## Fix

- **`cacheControlMiddleware`**: serve `text/html` responses (the shell + navigations) as `Cache-Control: no-cache` so they always revalidate and pick up new deploys immediately. Hashed assets (`*.js`/`*.css`) and API JSON keep `max-age=86400` (safe — assets are content-hashed).
- **`cacheMiddleware`**: skip storing HTML in `caches.default` for the same reason.

OPTIONS (204) and API/JSON responses are unaffected.

## Required one-time action after merge

This stops the shell from being cached **going forward**, but the **already-cached** shells live in the edge for up to ~24h. After this deploys, do a **one-time cache purge** of the Pages project (Cloudflare dashboard → Caching → Purge Everything). After that it self-heals — every future deploy is picked up immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)