### PR TITLE
fix(radial): show only OER pilots in the OER view

### DIFF
--- a/src/app/pages/radial-policies/radial-policies.page.ts
+++ b/src/app/pages/radial-policies/radial-policies.page.ts
@@ -74,6 +74,10 @@ export default class RadialPolicyPage extends BasePage implements OnInit {
     }
 
     private groupBySdg(policies: IntersectingPolicyDto[], limit: number): RadialStackedData[] {
+        // In the OER view, only the OER pilots (OER1–OER5) belong in the stack/legend; the pilot
+        // intersection endpoint also returns other pilots (OBIA1/2/3, …) which must be hidden here.
+        // For any non-OER pilot, keep showing every pilot as before.
+        const onlyOerPilots = (this.pilot() ?? '').toUpperCase().startsWith('OER');
         const topicSdgMap = new Map<string, RadialStackedData>();
 
         policies
@@ -82,6 +86,7 @@ export default class RadialPolicyPage extends BasePage implements OnInit {
                 sdg,
                 value
             })))
+            .filter(({ sdg }) => !onlyOerPilots || sdg.toUpperCase().startsWith('OER'))
             .forEach(({ topic, sdg, value }) => {
                 if (!topicSdgMap.has(topic)) {
                     topicSdgMap.set(topic, {


### PR DESCRIPTION
## Problem

In the radial stacked chart (`/education/radial`), the legend showed non-OER pilots (e.g. **OBIA2**, OBIA1, OBIA3) even when viewing an OER pilot. The pilot policy-intersection endpoint (`/policy/intersection/pilot/{pilot}`) returns **every** education pilot (OER1–OER5 *and* OBIA1/2/3, …), and `groupBySdg()` keys the stack by the response's `sdg` field — which is the pilot name — so all of them ended up in the stack/legend.

## Fix

In `radial-policies.page.ts` `groupBySdg()`: when the selected pilot is an OER pilot (`pilot` starts with `OER`), filter the stacked series to OER pilots only — so the legend shows just **OER1–OER5**. For any non-OER pilot, the chart still shows everything (unchanged).

```ts
const onlyOerPilots = (this.pilot() ?? '').toUpperCase().startsWith('OER');
...
.filter(({ sdg }) => !onlyOerPilots || sdg.toUpperCase().startsWith('OER'))
```

The legend/stack derive purely from the data keys, so hiding the non-OER series removes them from both.

## Verified
- `ng build --configuration production` passes.

## Note
This is the only chart using the multi-pilot `RadialStackedChart`. If any other widget shows the same all-pilots legend and should be OER-only, the same `pilot`-based filter applies — let me know.

🤖 Generated with [Claude Code](https://claude.com/claude-code)