### PR TITLE
feat(pilot): add OER-all pilot everywhere

### DIFF
--- a/configuration/pilot/pilot.configurationt.ts
+++ b/configuration/pilot/pilot.configurationt.ts
@@ -258,6 +258,69 @@ export const OER5_CONFIGURATION: SdgConfiguration = {
     ]
 };
 
+export const OER_ALL_CONFIGURATION: SdgConfiguration = {
+    id: 1100,
+    color: '#0D6EFD',
+    topics: [
+        {
+            name: 'Open Education & Capacity',
+            wikiConcepts: [
+                'Open educational resources',
+                'Capacity building',
+                'Continuing education',
+                'OpenCourseWare',
+                'Competency-based learning'
+            ]
+        },
+        {
+            name: 'Open Education & Policy',
+            wikiConcepts: [
+                'Open education',
+                'Open educational resources',
+                'Education policy',
+                'Law on the state education'
+            ]
+        },
+        {
+            name: 'Social Inclusion & Open Resources',
+            wikiConcepts: [
+                'Open educational resources',
+                'Social inclusion',
+                'Open format',
+                'Vulnerable adult'
+            ]
+        },
+        {
+            name: 'Finance & Innovation',
+            wikiConcepts: [
+                'Open educational resources',
+                'Financial modeling',
+                'Long-term incentive plan',
+                'Innovation'
+            ]
+        },
+        {
+            name: 'Research & Knowledge Sharing',
+            wikiConcepts: [
+                'Open educational resources',
+                'Translational research',
+                'Multilateral Agreement on Investment',
+                'Multilingual Education',
+                'Knowledge sharing',
+                'Public–private partnership'
+            ]
+        }
+    ],
+    indicators: [
+        { name: 'Open educational resources' },
+        { name: 'Capacity building' },
+        { name: 'Continuing education' },
+        { name: 'Education policy' },
+        { name: 'Social inclusion' },
+        { name: 'Financial modeling' }
+    ]
+};
+
 export const AI_MOVEMENT_CONFIGURATION: SdgConfiguration = {
     id: 1201,
     color: '#FF006E',

--- a/functions/api/news/topics/index.ts
+++ b/functions/api/news/topics/index.ts
@@ -11,6 +11,7 @@ const pilotURIMapped: Record<string, string> = {
     'OER3': '1ebf4034-deab-452e-a0e4-edf356eb2139',
     'OER4': '50c9b223-8eec-49ee-b6cb-46631ed37dcf',
     'OER5': 'f9d34ef5-0d04-4e2e-8fc7-ade59aef9801',
+    'OER-all': '9b82e68d-e7ee-4d64-98b1-a75af9c7f138',
     'OBIA1': '99f967a0-20fa-40aa-888f-67b203554d42', // TODO: Replace with actual UUID
     'OBIA2': '3b90568b-8d96-46bc-ae29-4b409e5a07df	', // TODO: Replace with actual UUID
     'OBIA3': 'ad8bfbf3-98ce-472d-8db3-42243ff610b5', // TODO: Replace with actual UUID

--- a/src/app/domain/configuration/service/configuration.ts
+++ b/src/app/domain/configuration/service/configuration.ts
@@ -18,7 +18,7 @@ import { SDG7_CONFIGURATION } from '../../../../../configuration/sdg/sdg7.config
 import { SDG8_CONFIGURATION } from '../../../../../configuration/sdg/sdg8.configuration';
 import { SDG9_CONFIGURATION } from '../../../../../configuration/sdg/sdg9.configuration';
 import { SdgConfiguration } from '../types/sdg-configuration.interface';
-import { AI_MOVEMENT_CONFIGURATION, COP30_CONFIGURATION, ELIAS_CONFIGURATION, LANDSLIDES_PILOT_CONFIGURATION, OBIA1_CONFIGURATION, OBIA2_CONFIGURATION, OBIA3_CONFIGURATION, OER1_CONFIGURATION, OER2_CONFIGURATION, OER3_CONFIGURATION, OER4_CONFIGURATION, OER5_CONFIGURATION, QUANTUM_CONFIGURATION, RAD_CONFIGURATION } from '../../../../../configuration/pilot/pilot.configurationt';
+import { AI_MOVEMENT_CONFIGURATION, COP30_CONFIGURATION, ELIAS_CONFIGURATION, LANDSLIDES_PILOT_CONFIGURATION, OBIA1_CONFIGURATION, OBIA2_CONFIGURATION, OBIA3_CONFIGURATION, OER1_CONFIGURATION, OER2_CONFIGURATION, OER3_CONFIGURATION, OER4_CONFIGURATION, OER5_CONFIGURATION, OER_ALL_CONFIGURATION, QUANTUM_CONFIGURATION, RAD_CONFIGURATION } from '../../../../../configuration/pilot/pilot.configurationt';
 
 @Injectable({
     providedIn: 'root'
@@ -79,6 +79,8 @@ export class Configuration {
                 return OER4_CONFIGURATION;
             case 'OER5':
                 return OER5_CONFIGURATION;
+            case 'OER-all':
+                return OER_ALL_CONFIGURATION;
             case 'OBIA1':
                 return OBIA1_CONFIGURATION;
             case 'OBIA2':

--- a/src/app/pages/landing/landing.page.ts
+++ b/src/app/pages/landing/landing.page.ts
@@ -116,6 +116,7 @@ export default class LandingPage {
             'OER3': 'OER3',
             'OER4': 'OER4',
             'OER5': 'OER5',
+            'OER-all': 'OER-all',
             'OBIA1': 'OBIA1',
             'OBIA2': 'OBIA2',
             'OBIA3': 'OBIA3',


### PR DESCRIPTION
## What

Adds the aggregate **OER-all** pilot so it can be selected and configured like OER1–OER5. The identifier is `OER-all` (hyphen) to match the tagging source (`IRCAI-ObsPilots.csv` → `PILOT002f, OER-all`) and thus the Elasticsearch `pilot.keyword`.

## Changes

- **`configuration/pilot/pilot.configurationt.ts`** — `OER_ALL_CONFIGURATION` (union of the five OER topics + their indicators).
- **`Configuration.get()`** — `case 'OER-all'` (without it, selecting OER-all throws "No configuration found").
- **`landing.page.ts`** — `OER-all` option in the pilot dropdown (after OER5).
- **`functions/api/news/topics/index.ts`** — `pilotURIMapped['OER-all']` → ER-key `9b82e68d-…` from the pilots CSV.

The existing OER detection already uses `startsWith('OER')` — news widget `isOer` (Region dropdown) and the radial `onlyOerPilots` filter — so **OER-all is automatically treated as an OER pilot** there (shows the Region dropdown; the radial keeps only OER pilots).

## Note

`OER-all` currently returns no data from the news/policy endpoints yet (not ingested at the time of writing) — this PR is the front-end wiring so it works as soon as the data lands. Verified `ng build --configuration production` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)