### PR TITLE
fix(cache): never cache /api/* responses (fixes stale OER-all etc.)

### DIFF
--- a/functions/middleware/cache-control.middleware.ts
+++ b/functions/middleware/cache-control.middleware.ts
@@ -1,10 +1,11 @@
-export const cacheControlMiddleware: PagesFunction = async ({ next }) => {
+export const cacheControlMiddleware: PagesFunction = async ({ request, next }) => {
     const response = await next();
 
     if (response.status === 200) {
         const contentType = response.headers.get('Content-Type') ?? '';
+        const isApi = new URL(request.url).pathname.startsWith('/api/');
 
-        if (contentType.includes('text/html')) {
+        if (isApi || contentType.includes('text/html')) {
             // The SPA shell (index.html / navigations) must always revalidate, otherwise a
             // deploy stays invisible for up to a day because the old shell keeps pointing at
             // the old hashed JS bundles. The bundles themselves are content-hashed, so the

--- a/functions/middleware/cache.middleware.ts
+++ b/functions/middleware/cache.middleware.ts
@@ -2,11 +2,15 @@ export const cacheMiddleware: PagesFunction = async ({ request, next }) => {
     const cache = caches.default;
     const cacheKey = request.url;
 
-    // Navigation requests (the SPA shell) must never be served from cache — neither read nor
-    // written — so a new deploy is picked up immediately instead of staying stale for ~24h.
+    // Never serve from cache for:
+    //  - navigation requests (the SPA shell) — so a new deploy is picked up immediately;
+    //  - API requests (/api/*) — so freshly ingested/tagged data shows up immediately instead
+    //    of returning a stale (e.g. empty) response cached for ~24h.
     const wantsHtml = (request.headers.get('Accept') ?? '').includes('text/html');
+    const isApi = new URL(request.url).pathname.startsWith('/api/');
+    const skipCache = wantsHtml || isApi;
 
-    if (!wantsHtml && request.headers.get('Cache-Control') !== 'no-cache') {
+    if (!skipCache && request.headers.get('Cache-Control') !== 'no-cache') {
         const cachedResponse = await cache.match(cacheKey);
 
         if (cachedResponse) {
@@ -16,11 +20,10 @@ export const cacheMiddleware: PagesFunction = async ({ request, next }) => {
     }
     const response = await next();
 
-    // Never cache the SPA shell (index.html / navigations) — it must always be re-fetched so
-    // a new deploy is picked up immediately. Hashed assets and API responses still get cached.
+    // Don't store the SPA shell or API responses (see above). Hashed static assets still cache.
     const isHtml = (response.headers.get('Content-Type') ?? '').includes('text/html');
 
-    if (response.status === 200 && !isHtml) {
+    if (response.status === 200 && !isHtml && !isApi) {
         console.log('Caching response', cacheKey);
         await cache.put(cacheKey, response.clone());
     }


### PR DESCRIPTION
## Problem

The news widget kept showing **no data for OER-all** even though Elasticsearch has ~87k OER-all docs with recent `dateTimePub`. Root cause: the Pages middleware cached **API** responses for 24h (`caches.default` + `Cache-Control: public, max-age=86400`). When a pilot/date had no data at query time, the **empty** response got cached, so newly ingested/tagged data stayed invisible for up to a day. (`&v=` on the page URL doesn't help — it only busts the HTML shell, not the per-day `/api/news/articles?...` calls.)

Verified: `/api/news/articles?...&pilot=OER-all&date=2026-06-05...` → `0` (cached), same URL `+&cb=` → `630` (fresh).

## Fix

Treat `/api/*` like the SPA shell:
- **`cache.middleware.ts`**: skip the Worker cache (`caches.default`) for API requests — neither read nor write. This also bypasses already-cached stale API entries immediately.
- **`cache-control.middleware.ts`**: send `Cache-Control: no-cache` for `/api/*` (so the CDN doesn't cache them going forward).

Hashed static assets (`*.js`/`*.css`) keep the long cache; the SPA shell stays `no-cache` as before.

## Effect

News/API data is always fresh — no purge needed, and the OER-all data shows up immediately once this deploys. Slightly more load on the upstream Elasticsearch (news API is low-traffic, so fine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)