### PR TITLE
feat(news): visibly animate the date walk for OER

### DIFF
--- a/src/app/pages/news/news.page.ts
+++ b/src/app/pages/news/news.page.ts
@@ -190,7 +190,13 @@ export default class NewsPage extends BasePage implements OnInit {
     // Pilots can have no news for many recent days. Probe for the most recent day that
     // actually has news and jump straight to it, so the widget lands on data instead of
     // walking day-by-day through empty dates.
+    // OER is intentionally excluded: there we want the widget to visibly animate through the
+    // days (empty ones included) so viewers see it is live (see startCounter).
     private jumpToLatestNewsDate() {
+        if (this.isOer()) {
+            return;
+        }
+
         this.newsService.getLatestNewsDate(+this.sdg()!, this.pilot()!).subscribe(latestDate => {
             this.latestDate = latestDate ?? new Date();
             this.shownDate$.next(this.latestDate);
@@ -282,22 +288,28 @@ export default class NewsPage extends BasePage implements OnInit {
     }
 
     private startCounter() {
-        // Drive the date walk off the rendered news: dwell on days that have
-        // news, but skip empty days near-instantly so pilots whose latest news
-        // is weeks old don't sit on a blank "No news today" screen. The dwell
-        // applies to the filtered result, so an active region/topic filter also
-        // skips straight to days that have matching news.
+        // Drive the date walk off the rendered news: dwell on days that have news.
+        // For OER we visibly animate through empty days too (short dwell) so viewers see the
+        // widget is live; for every other pilot/SDG we skip empty days near-instantly so a
+        // pilot whose latest news is weeks old doesn't sit on a blank "No news today" screen.
         return this.news$.pipe(
-            switchMap(news => timer(news.length ? this.dwellMs : this.skipMs)),
+            switchMap(news => {
+                if (news.length) {
+                    return timer(this.dwellMs);
+                }
+
+                return timer(this.isOer() ? this.oerEmptyDwellMs : this.skipMs);
+            }),
             tap(() => {
                 const currentDate = new Date(this.shownDate$.value);
 
                 if (currentDate >= this.minDate) {
                     this.shownDate$.next(new Date(currentDate.setDate(currentDate.getDate() - 1)));
                 } else {
-                    // Restart the rotation at the latest day with news (not today), so we
-                    // don't re-walk the empty recent days every cycle.
-                    this.shownDate$.next(this.latestDate ?? new Date());
+                    // Restart the rotation: OER walks again from today (visible animation),
+                    // others restart at the latest day with news so they don't re-walk the
+                    // empty recent days every cycle.
+                    this.shownDate$.next(this.isOer() ? new Date() : (this.latestDate ?? new Date()));
                 }
             }),
         ).subscribe();
@@ -305,6 +317,7 @@ export default class NewsPage extends BasePage implements OnInit {
 
     private readonly dwellMs = 5000;
     private readonly skipMs = 100;
+    private readonly oerEmptyDwellMs = 1500;
     private latestDate?: Date;
 
     private get minDate() {


### PR DESCRIPTION
## What

For **OER** pilots (incl. `OER-all`) the news widget now **visibly animates** through the dates so viewers can see it's live, instead of instantly jumping to the latest day with news.

- Walks day-by-day from **today** backwards.
- Dwells **5s** on a day that has news, **~1.5s** on an empty day (showing "No news today").
- Loops back to today when it reaches the 31-day window edge.

**All other pilots/SDGs are unchanged**: jump straight to the latest day with news and skip empty days in ~100ms.

## How

- `jumpToLatestNewsDate()` is a no-op for OER (so it starts at today and walks).
- `startCounter()`: empty-day dwell = `1500ms` for OER vs `100ms` otherwise; the rotation restart point is **today** for OER vs the latest news day otherwise.

Per the request: *"pri OER mora delati animacija … če ni podatkov naj pokaže news brez, da vidijo da dela; medtem ko ostali skače naprej."*

## Note

Could not run a local `ng build` (the working copy's `node_modules` was removed and the local env has no usable pnpm; npm rejects the `angular-tag-cloud-module` peer range). The change is logic-only — no new imports, template, or type changes — so it compiles if `main` does; Cloudflare CI (pnpm) will verify on deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)