### PR TITLE
feat(news): name each OER action area in its label tooltip

### DIFF
--- a/configuration/pilot/oer-action-areas.ts
+++ b/configuration/pilot/oer-action-areas.ts
@@ -12,6 +12,19 @@ export const OER_ACTION_AREAS = [ 'OER1', 'OER2', 'OER3', 'OER4', 'OER5' ] as co
 export type OerActionArea = typeof OER_ACTION_AREAS[number];
 
 /**
+ * Human-readable names for the five action areas. The article labels stay as the short OER1..OER5
+ * codes — most articles match four areas at once, and four full names would outgrow the headline
+ * they sit under — so these are surfaced as the label's tooltip instead.
+ */
+export const OER_ACTION_AREA_NAMES: Record<OerActionArea, string> = {
+    OER1: 'Capacity Building',
+    OER2: 'Supportive Policy',
+    OER3: 'Inclusive Access',
+    OER4: 'Sustainable Models',
+    OER5: 'International Cooperation',
+};
+
+/**
  * Chip colours for the action-area labels shown next to each article. Pale backgrounds with a
  * same-hue dark text keep the labels readable inline next to the publication date; the hues
  * follow the per-area `color` in pilot.configurationt.ts.

--- a/src/app/pages/news/news.page.ts
+++ b/src/app/pages/news/news.page.ts
@@ -5,7 +5,7 @@ import { FormsModule } from '@angular/forms';
 import { CloudData, TagCloudComponent } from 'angular-tag-cloud-module';
 import { Checkbox } from 'primeng/checkbox';
 import { BehaviorSubject, combineLatestWith, distinctUntilChanged, EMPTY, filter, fromEvent, map, Observable, shareReplay, switchMap, tap, timer } from 'rxjs';
-import { OER_ACTION_AREA_STYLES, OER_ACTION_AREAS, OER_ALL_PILOT, oerActionAreasOf } from '../../../../configuration/pilot/oer-action-areas';
+import { OER_ACTION_AREA_NAMES, OER_ACTION_AREA_STYLES, OER_ACTION_AREAS, OER_ALL_PILOT, oerActionAreasOf } from '../../../../configuration/pilot/oer-action-areas';
 import { UNESCO_REGIONS } from '../../../../configuration/regions/unesco-regions';
 import { ElasticNewsItem } from '../../../../functions/api/news/articles/interface/elastic-news-item';
 import { NewsService } from '../../domain/news/service/news.service';
@@ -165,6 +165,7 @@ import { BasePage } from '../base.page';
                             @if (isOerAll()) {
                                 @for (area of actionAreasOf(newsItem); track area) {
                                     <span class="rounded px-1.5 text-base font-semibold"
+                                          [title]="actionAreaNames[area]"
                                           [style.background]="actionAreaStyles[area].background"
                                           [style.color]="actionAreaStyles[area].color">{{ area }}</span>
                                 }
@@ -219,6 +220,7 @@ export default class NewsPage extends BasePage implements OnInit {
     // labelled with each area it matches. The OER-all stream itself stays in the system.
     public readonly newsPilot = computed(() => this.isOerAll() ? OER_ACTION_AREAS.join(',') : this.pilot()!);
     public readonly actionAreaStyles = OER_ACTION_AREA_STYLES;
+    public readonly actionAreaNames = OER_ACTION_AREA_NAMES;
 
     public shownDate$ = new BehaviorSubject(new Date());
     public loadedDate$ = new BehaviorSubject(new Date());

--- a/src/app/pages/radial-policies/radial-policies.page.ts
+++ b/src/app/pages/radial-policies/radial-policies.page.ts
@@ -3,6 +3,7 @@ import { Component, inject, OnInit } from '@angular/core';
 import { toObservable } from '@angular/core/rxjs-interop';
 import { combineLatest, map, Observable } from 'rxjs';
 import { getSDGColor, SDG_COLORS } from '../../../../configuration/colors/policy/sdg.colors';
+import { OER_ACTION_AREA_NAMES } from '../../../../configuration/pilot/oer-action-areas';
 import { loadingMap } from '../../common/utility/loading-map';
 import { PolicyService } from '../../domain/policy/service/policy.service';
 import { IntersectingPolicyDto } from '../../domain/policy/types/intersecting-policy.dto';
@@ -43,14 +44,9 @@ import { BasePage } from '../base.page';
     `
 })
 export default class RadialPolicyPage extends BasePage implements OnInit {
-    // Human-readable names shown for the OER policies (pilot view segments).
-    private static readonly OER_LABELS: Record<string, string> = {
-        OER1: 'Capacity Building',
-        OER2: 'Supportive Policy',
-        OER3: 'Inclusive Access',
-        OER4: 'Sustainable Models',
-        OER5: 'International Cooperation',
-    };
+    // Human-readable names shown for the OER policies (pilot view segments). Shared with the news
+    // widget, which shows the same names as tooltips on its action-area labels.
+    private static readonly OER_LABELS: Record<string, string> = OER_ACTION_AREA_NAMES;
     private static readonly OER_COLORS: Record<string, string> = {
         OER1: '#4C9F38',
         OER2: '#FCC30B',


### PR DESCRIPTION
The OER-all labels showed the bare OER1..OER5 codes, which say nothing to a reader. Hovering one now names the action area — "Supportive Policy" for OER2, and so on.

The codes stay as the visible label: most articles match four areas at once, so four full names would outgrow the headline they sit under.

The radial-policies page already had these names; both pages now read them from configuration/pilot/oer-action-areas.ts so the wording cannot drift.